### PR TITLE
Add additional tests around console.log

### DIFF
--- a/.mocharc.cjs
+++ b/.mocharc.cjs
@@ -1,6 +1,7 @@
 const path = require('path');
 
 module.exports = {
-  spec: path.join(__dirname, 'test/**/**/*.spec.js'),
-  timeout: 30000
+  spec: path.join(__dirname, "test/**/**/*.spec.js"),
+  timeout: 30000,
+  require: ["test/hooks.js"],
 };

--- a/test/cases/runner-cli-create-output-false/runner.cli-create-output-false.spec.js
+++ b/test/cases/runner-cli-create-output-false/runner.cli-create-output-false.spec.js
@@ -28,7 +28,7 @@ describe('CLI Fixture', function() {
       runner.setup(outputPath, null, { create: false });
     });
 
-    it('should have created the output folder', function() {
+    it('should not have created the output folder', function() {
       const exists = fs.existsSync(outputPath);
 
       expect(exists).to.be.equal(false);

--- a/test/cases/runner-cli-error/runner-cli-error.spec.js
+++ b/test/cases/runner-cli-error/runner-cli-error.spec.js
@@ -12,10 +12,14 @@
  */
 import * as chai from 'chai';
 import chaiAsPromised from 'chai-as-promised';
+import fs from 'fs';
 import path from 'path';
+import sinon from 'sinon';
+import sinonChai from 'sinon-chai';
 import { Runner } from '../../../src/index.js';
 
 chai.use(chaiAsPromised);
+chai.use(sinonChai);
 const { expect } = chai;
 
 describe('CLI Error Handling', function() {
@@ -52,6 +56,26 @@ describe('CLI Error Handling', function() {
         'Error: Child process throwing a Promise.reject to the parent.'
       );
     });
+
+    for (const withSetup of [true, false]) {
+      it('should throw and log to console when teardown fails', async function() {
+        const testString = 'TEST';
+        const testError = new Error(testString);
+        const consoleFake = sinon.fake();
+        sinon.replace(console, 'log', consoleFake);
+        sinon.replace(fs, 'existsSync', sinon.fake.throws(testError));
+        const runner = new Runner();
+        
+        if (withSetup) {
+          runner.setup(process.cwd(), ["fake-file-name.txt"]);
+        } else {
+          runner.setupFiles = null;
+        }
+        await expect(runner.teardown(['fake-file-name.txt'])).to.be.rejectedWith(testString);
+
+        expect(consoleFake).to.have.been.calledOnceWithExactly(testError);
+      });
+    }
   });
 
 });

--- a/test/cases/runner-cli-stop/runner.cli-stop.spec.js
+++ b/test/cases/runner-cli-stop/runner.cli-stop.spec.js
@@ -65,8 +65,8 @@ describe('Server Fixture for Manual Process Stop', function() {
       runner.stopCommand();
     });
 
-    after(function() {
-      runner.teardown([
+    after(async function() {
+      await runner.teardown([
         path.join(outputPath)
       ]);
     });

--- a/test/cases/runner-debug/runner.debug.spec.js
+++ b/test/cases/runner-debug/runner.debug.spec.js
@@ -61,8 +61,8 @@ describe('CLI Fixture w/debug (stdOut) enabled', function() {
       expect(consoleFake).to.have.been.calledOnceWithExactly(testString);
     });
 
-    after(function() {
-      runner.teardown([
+    after(async function() {
+      await runner.teardown([
         path.join(outputPath)
       ]);
     });

--- a/test/cases/runner-debug/runner.debug.spec.js
+++ b/test/cases/runner-debug/runner.debug.spec.js
@@ -10,12 +10,14 @@
  * runCommand('test/fixtures/cli', 'test/fixtures')
  *
  */
-import fs from 'fs-extra';
 import * as chai from 'chai';
 import path from 'path';
+import sinon from 'sinon';
+import sinonChai from 'sinon-chai';
 import { Runner } from '../../../src/index.js';
 import { fileURLToPath, URL } from 'url';
 
+chai.use(sinonChai);
 const { expect } = chai;
 
 describe('CLI Fixture w/debug (stdOut) enabled', function() {
@@ -25,37 +27,38 @@ describe('CLI Fixture w/debug (stdOut) enabled', function() {
   describe('default options with relative path', function() {
     let runner;
 
-    before(function() {
-      runner = new Runner();
-      runner.setup(outputPath);
-      runner.runCommand(
-        `${fixturesPath}/cli.js`, // binPath
-        fixturesPath // args
+    before(async function() {
+      runner = new Runner(true);
+    });
+
+    it('should write to console.log', async function() {
+      const testString = 'TEST';
+      const consoleFake = sinon.fake();
+      sinon.replace(console, 'log', consoleFake);
+
+      await runner.runCommand(
+        `${fixturesPath}/cli-write-to-stdout.js`,
+        null,
+        { async: true }
       );
+
+      expect(consoleFake).to.have.been.calledOnceWithExactly(testString);
     });
 
-    it('should have created the output folder', function() {
-      const exists = fs.existsSync(outputPath);
+    it('should write stderr to console.log', async function () {
+      const testString = 'TEST ERROR';
+      const consoleFake = sinon.fake();
+      sinon.replace(console, 'error', consoleFake);
 
-      expect(exists).to.be.equal(true);
-    });
+      await expect(
+        runner.runCommand(
+          path.join(process.cwd(), 'test/fixtures/cli-write-to-stderr.js'),
+          null,
+          { async: true }
+        )
+      ).to.be.rejectedWith(testString);
 
-    it('should only copy 3 files', function() {
-      const files = fs.readdirSync(outputPath);
-
-      expect(files.length).to.be.equal(3);
-    });
-
-    it('should have an .editorconfig file', function() {
-      expect(fs.existsSync(`${outputPath}/.editorconfig`)).to.be.equal(true);
-    });
-
-    it('should have an .eslintrc file', function() {
-      expect(fs.existsSync(`${outputPath}/.eslintrc.cjs`)).to.be.equal(true);
-    });
-
-    it('should have .mocharc file', function() {
-      expect(fs.existsSync(`${outputPath}/.mocharc.cjs`)).to.be.equal(true);
+      expect(consoleFake).to.have.been.calledOnceWithExactly(testString);
     });
 
     after(function() {

--- a/test/cases/runner-forward-args/runner.forward-args.spec.js
+++ b/test/cases/runner-forward-args/runner.forward-args.spec.js
@@ -52,8 +52,8 @@ describe('Forward Parent Args', function() {
       expect(contents).to.be.equal('--debug-port=3333');
     });
 
-    after(function() {
-      runner.teardown([
+    after(async function() {
+      await runner.teardown([
         path.join(outputPath)
       ]);
     });

--- a/test/fixtures/cli-write-to-stderr.js
+++ b/test/fixtures/cli-write-to-stderr.js
@@ -1,0 +1,2 @@
+const testString = "TEST ERROR";
+process.stderr.write(testString);

--- a/test/fixtures/cli-write-to-stdout.js
+++ b/test/fixtures/cli-write-to-stdout.js
@@ -1,0 +1,2 @@
+const testString = "TEST";
+process.stdout.write(testString);

--- a/test/hooks.js
+++ b/test/hooks.js
@@ -1,0 +1,7 @@
+import sinon from "sinon";
+
+export const mochaHooks = {
+  afterEach() {
+    sinon.restore();
+  },
+};


### PR DESCRIPTION
Assuming no new code is merged in first, this will get us to 100% test coverage.

<img width="634" height="390" alt="image" src="https://github.com/user-attachments/assets/5e245fb4-976f-4072-96d5-47b0b8b90cc3" />

Also depends on https://github.com/thescientist13/gallinago/pull/60 being merged first.

## Related Issue
https://github.com/thescientist13/gallinago/issues/9

## Summary of Changes
1. [x] Added tests for the remaining uncovered lines (mostly console.log)
2. [x] Added test for when teardown fails
3. [x] Added mocha root hook for sinon.restore to prevent tests from interfering with each other, as recommended by the sinon library.